### PR TITLE
Fix test compilation and unused imports

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/stretchr/testify v1.8.3
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.0
-	github.com/swaggo/swag v1.16.2
 	go.uber.org/zap v1.26.0
 	golang.org/x/crypto v0.28.0
 	gorm.io/driver/postgres v1.5.4
@@ -54,6 +53,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
+	github.com/swaggo/swag v1.16.2 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect
 	go.uber.org/multierr v1.10.0 // indirect

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"elterngeld-portal/internal/models"
-	"elterngeld-portal/pkg/auth"
 	"elterngeld-portal/tests/testutils"
 
 	"github.com/gin-gonic/gin"

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -2,16 +2,15 @@ package integration
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
-	"time"
 
 	"elterngeld-portal/internal/models"
 	"elterngeld-portal/internal/server"
 	"elterngeld-portal/tests/testutils"
+
+	"github.com/gin-gonic/gin"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Resolve all compilation errors by cleaning up imports and refactoring logger tests.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `pkg/logger/logger_test.go` file had errors related to assigning to `os.Exit` for mocking. This was fixed by restructuring the test to initialize the logger and test the code path without directly assigning to `os.Exit`, as it's not an addressable variable.

---
<a href="https://cursor.com/background-agent?bcId=bc-88d7dbe1-6472-4966-9b08-04eb66dca715">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-88d7dbe1-6472-4966-9b08-04eb66dca715">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>