### PR TITLE
Handle build test error

### DIFF
--- a/tests/testutils/utils.go
+++ b/tests/testutils/utils.go
@@ -55,6 +55,10 @@ func SetupTestContext(t *testing.T) *TestContext {
 			AccessExpiry:  15 * time.Minute,
 			RefreshExpiry: 7 * 24 * time.Hour,
 		},
+		RateLimit: config.RateLimitConfig{
+			Requests: 1000, // High limit for tests to avoid rate limiting
+			Window:   60,
+		},
 	}
 
 	// Initialize logger


### PR DESCRIPTION
Add rate limit configuration to test context to prevent tests from failing due to HTTP 429 errors.

The test configuration was defaulting rate limits to zero, causing all test requests to be immediately rate-limited with HTTP 429 responses.

---
<a href="https://cursor.com/background-agent?bcId=bc-cb7d211b-384e-4d84-a76f-198efb7c5487">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cb7d211b-384e-4d84-a76f-198efb7c5487">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>