### PR TITLE
Lint code for jwt errors

### DIFF
--- a/pkg/auth/jwt.go
+++ b/pkg/auth/jwt.go
@@ -140,7 +140,7 @@ func (js *JWTService) IsTokenExpired(tokenString string) bool {
 		return true
 	}
 
-	return claims.ExpiresAt.Time.Before(time.Now())
+	return claims.RegisteredClaims.ExpiresAt.Time.Before(time.Now())
 }
 
 // GetTokenClaims extracts claims from a token without validation (for expired tokens)
@@ -278,7 +278,7 @@ func (js *JWTService) ValidateTokenWithBlacklist(tokenString string) (*Claims, e
 	}
 
 	// Check if token is blacklisted
-	if GlobalTokenBlacklist.IsBlacklisted(claims.ID) {
+	if GlobalTokenBlacklist.IsBlacklisted(claims.RegisteredClaims.ID) {
 		return nil, ErrTokenBlacklisted
 	}
 
@@ -292,6 +292,6 @@ func (js *JWTService) BlacklistToken(tokenString string) error {
 		return err
 	}
 
-	GlobalTokenBlacklist.Add(claims.ID, claims.ExpiresAt.Time)
+	GlobalTokenBlacklist.Add(claims.RegisteredClaims.ID, claims.RegisteredClaims.ExpiresAt.Time)
 	return nil
 }

--- a/pkg/auth/jwt_test.go
+++ b/pkg/auth/jwt_test.go
@@ -59,9 +59,9 @@ func TestValidateAccessToken(t *testing.T) {
 	assert.Equal(t, user.ID, claims.UserID)
 	assert.Equal(t, user.Email, claims.Email)
 	assert.Equal(t, user.Role, claims.Role)
-	assert.Equal(t, "elterngeld-portal", claims.Issuer)
-	assert.Equal(t, user.ID.String(), claims.Subject)
-	assert.Contains(t, claims.Audience, "elterngeld-portal-api")
+	assert.Equal(t, "elterngeld-portal", claims.RegisteredClaims.Issuer)
+	assert.Equal(t, user.ID.String(), claims.RegisteredClaims.Subject)
+	assert.Contains(t, claims.RegisteredClaims.Audience, "elterngeld-portal-api")
 }
 
 func TestValidateAccessToken_InvalidToken(t *testing.T) {


### PR DESCRIPTION
Explicitly access embedded `jwt.RegisteredClaims` fields in `jwt.go` to resolve linting errors.

The linting errors (e.g., "claims.ExpiresAt undefined") occurred because the `Claims` struct embeds `jwt.RegisteredClaims`, but Go requires explicit access to these embedded fields (e.g., `claims.RegisteredClaims.ExpiresAt`) when there are potential naming conflicts or the compiler cannot resolve them automatically.

---
<a href="https://cursor.com/background-agent?bcId=bc-5c2d5061-f7fe-43c7-86bf-5d4ebd829ba9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5c2d5061-f7fe-43c7-86bf-5d4ebd829ba9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>