### PR TITLE
Run tests and fix errors

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -84,7 +84,9 @@ func (s *Server) setupMiddleware() {
 func (s *Server) setupRoutes() {
 	// Health check endpoint
 	s.Router.GET("/health", s.healthCheck)
+	s.Router.HEAD("/health", s.healthCheck) // Support HEAD requests for health checks
 	s.Router.GET("/ready", s.readinessCheck)
+	s.Router.HEAD("/ready", s.readinessCheck) // Support HEAD requests for readiness checks
 
 	// Swagger documentation
 	if s.config.IsDevelopment() {


### PR DESCRIPTION
Fixes all `make test` failures by adding HEAD support for server health checks and refactoring logger tests.

The `make test` command was failing due to several issues:
*   **Server**: HEAD requests for `/health` and `/ready` were not explicitly handled by Gin, causing a 404.
*   **Logger**: Tests were brittle due to complex output capture logic, incorrect string assertions for console output, and the `captureLogOutput` helper not respecting the configured log level, leading to false failures and output pollution. This PR refactors the logger tests and the `captureLogOutput` helper to be more robust and accurate.

---
<a href="https://cursor.com/background-agent?bcId=bc-da4a0470-a072-492b-98a5-b609b6b1f847">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-da4a0470-a072-492b-98a5-b609b6b1f847">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>